### PR TITLE
Update DNS Records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,23 @@ check: lint test cover
 
 fmt:
 	go fmt ./...
+
+# dlv debug -- dns update --dnszone=jeff --rrnames="*.jeff.ois.run."
+# Type 'help' for list of commands.
+# (dlv) break cmd.debug
+# Breakpoint 1 set at 0x1a17cd3 for github.com/openinfrastructure/scarab/cmd.debug() ./cmd/dns_update.go:129
+# (dlv) continue
+# Version string empty
+# > github.com/openinfrastructure/scarab/cmd.debug() ./cmd/dns_update.go:129 (hits goroutine(1):1 total:1) (PC: 0x1a17cd3)
+#    124:         }
+#    125:
+#    126:         log.Println(c)
+#    127: }
+#    128:
+# => 129: func debug(c *dns.Change) bool {
+#    130:         log.Println(c)
+#    131:         return false
+#    132: }
+# (dlv)
+debug:
+	dlv debug -- dns update --dnszone=jeff --rrnames="*.jeff.ois.run."

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -14,32 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scarab
+package cmd
 
 import (
-	"context"
-	"log"
-
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/dns/v1"
+	"github.com/spf13/cobra"
 )
 
-// NewService returns the GCP Compute API.
-// See: https://godoc.org/google.golang.org/api/compute/v1
-func NewService() *compute.Service {
-	svc, err := compute.NewService(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
-	return svc
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manage Cloud DNS resources",
+	Long:  "Manage Cloud DNS resources",
+	Run:   dnsCmdMain,
 }
 
-// NewDNSService returns the GCP DNS API.  See:
-// https://godoc.org/google.golang.org/api/dns/v1
-func NewDNSService() *dns.Service {
-	svc, err := dns.NewService(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
-	return svc
+func dnsCmdMain(cmd *cobra.Command, args []string) {
+	cmd.Usage()
+}
+
+func init() {
+	rootCmd.AddCommand(dnsCmd)
 }

--- a/cmd/dns_list.go
+++ b/cmd/dns_list.go
@@ -14,32 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scarab
+package cmd
 
 import (
-	"context"
 	"log"
 
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/dns/v1"
+	"github.com/openinfrastructure/scarab/common/scarab"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-// NewService returns the GCP Compute API.
-// See: https://godoc.org/google.golang.org/api/compute/v1
-func NewService() *compute.Service {
-	svc, err := compute.NewService(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
-	return svc
+var dnsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List DNS managed zones",
+	Long:  "List DNS managed zones in the specified project",
+	Run:   dnsListCmdMain,
 }
 
-// NewDNSService returns the GCP DNS API.  See:
-// https://godoc.org/google.golang.org/api/dns/v1
-func NewDNSService() *dns.Service {
-	svc, err := dns.NewService(context.Background())
+func init() {
+	dnsCmd.AddCommand(dnsListCmd)
+}
+
+func dnsListCmdMain(cmd *cobra.Command, args []string) {
+	validateConfig()
+
+	project := viper.GetString("project")
+	svc := scarab.NewDNSService()
+
+	l, err := svc.ManagedZones.List(project).Do()
 	if err != nil {
 		log.Fatal(err)
 	}
-	return svc
+
+	for _, i := range l.ManagedZones {
+		log.Println(i.Name)
+	}
 }

--- a/cmd/dns_update.go
+++ b/cmd/dns_update.go
@@ -1,0 +1,128 @@
+/*
+Copyright © 2019 Open Infrastructure Services, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/openinfrastructure/scarab/common/scarab"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/api/dns/v1"
+)
+
+var dnsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update DNS records",
+	Long:  "Update DNS resource records in the specified zone atomically",
+	Run:   dnsUpdateCmdMain,
+}
+
+func init() {
+	dnsCmd.AddCommand(dnsUpdateCmd)
+
+	// DNS Manged Zone to change
+	dnsUpdateCmd.PersistentFlags().String("dnszone", "", "The managed zone {SCARAB_DNSZONE}")
+	if err := viper.BindPFlag("dnszone", dnsUpdateCmd.PersistentFlags().Lookup("dnszone")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Resource Record names to update (for example, the fqdn)
+	dnsUpdateCmd.PersistentFlags().StringSlice("rrnames", []string{}, "The record names to update (fqdns) {SCARAB_RRNAMES}")
+	if err := viper.BindPFlag("rrnames", dnsUpdateCmd.PersistentFlags().Lookup("rrnames")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Resource Record type, for example "A" for an A record.
+	dnsUpdateCmd.PersistentFlags().String("rrtype", "A", "The DNS record type {SCARAB_RRTYPE}")
+	if err := viper.BindPFlag("rrtype", dnsUpdateCmd.PersistentFlags().Lookup("rrtype")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Resource Record TTL
+	dnsUpdateCmd.PersistentFlags().Int64("rrttl", 60, "The DNS record TTL {SCARAB_RRTTL}")
+	if err := viper.BindPFlag("rrttl", dnsUpdateCmd.PersistentFlags().Lookup("rrttl")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Resource Record data values to update to (for example, the IP address)
+	dnsUpdateCmd.PersistentFlags().StringSlice("rrdatas", []string{}, "The new record values (addresses).  If not provided, remove the record. {SCARAB_RRDATAS}")
+	if err := viper.BindPFlag("rrdatas", dnsUpdateCmd.PersistentFlags().Lookup("rrdatas")); err != nil {
+		log.Fatal(err)
+	}
+}
+
+/* dnsUpdateCmdMain Atomically updates the ResourceRecordSet collection using
+the [DNS v1 Changes
+API](https://cloud.google.com/dns/docs/reference/v1/changes).
+
+TODO: Help the user if they forget a trailing dot (.) on the FQDN, otherwise they get:
+Reason: invalid, Message: Invalid value for 'entity.change.additions[0].name': 'jeff.ois.run'
+Reason: invalid, Message: Invalid value for 'entity.change.additions[1].name': 'foo.jeff.ois.run'
+*/
+func dnsUpdateCmdMain(cmd *cobra.Command, args []string) {
+	validateConfig()
+
+	project := viper.GetString("project")
+	dnszone := viper.GetString("dnszone")
+	rrnames := viper.GetStringSlice("rrnames")
+	rrdatas := viper.GetStringSlice("rrdatas")
+	rrtype := viper.GetString("rrtype")
+	rrttl := viper.GetInt64("rrttl")
+
+	svc := scarab.NewDNSService()
+
+	if len(rrnames) < 1 {
+		log.Fatalf("At least one value for rrnames is required.")
+	}
+
+	// See: https://cloud.google.com/dns/docs/reference/v1/changes#resource
+	change := &dns.Change{}
+
+	for _, name := range rrnames {
+		if len(rrdatas) > 0 {
+			a := &dns.ResourceRecordSet{
+				Name:    name,
+				Rrdatas: rrdatas,
+				Ttl:     rrttl,
+				Type:    rrtype,
+			}
+			change.Additions = append(change.Additions, a)
+		}
+
+		// If the name already exists it needs to be added to the deletions field
+		// of the Change resource.
+		rr, err := svc.ResourceRecordSets.List(project, dnszone).Name(name).Type(rrtype).Do()
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Add existing records to the list of records to delete in the change transaction.
+		for _, rrset := range rr.Rrsets {
+			change.Deletions = append(change.Deletions, rrset)
+		}
+	}
+
+	_, err := scarab.DoDNSChange(svc, project, dnszone, change)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func debug(c *dns.Change) bool {
+	log.Println(c)
+	return false
+}

--- a/common/scarab/api.go
+++ b/common/scarab/api.go
@@ -43,3 +43,15 @@ func NewDNSService() *dns.Service {
 	}
 	return svc
 }
+
+// DoDNSChange executes a DNS Change requiest if and only if the change
+// resource has at least one insertion or at least one deletion.
+func DoDNSChange(svc *dns.Service, project string, dnszone string, change *dns.Change) (c *dns.Change, err error) {
+	if (len(change.Additions) < 1) && (len(change.Deletions) < 1) {
+		log.Println("No changes to make")
+		return change, nil
+	}
+	c, err = svc.Changes.Create(project, dnszone, change).Do()
+	log.Println("Change status:", c.Status)
+	return c, err
+}


### PR DESCRIPTION
This patch adds a `scarab dns update` command to update records.  The intent is to pass in a new IP address when a new dynamic IP is obtained and automatically update at least the apex and the wildcard A records in Cloud DNS.

See [Changes](https://cloud.google.com/dns/docs/reference/v1/changes#resource) for the most detailed information about the changes API used to update DNS records.
